### PR TITLE
Update cpi.dta and change value of pi to 0.55

### DIFF
--- a/Code/FirmSummaryStats.do
+++ b/Code/FirmSummaryStats.do
@@ -10,7 +10,7 @@ tsset permno year
 
  
 * rescale measure by 1-prob of acceptance
-replace  Af=Af/(1-0.56) * 100
+replace  Af=Af/(1-0.55) * 100
 
 replace  Acw=Acw * 100
 

--- a/Code/PatentValueCites.do
+++ b/Code/PatentValueCites.do
@@ -88,7 +88,7 @@ replace  m_graw3m0FE= m_graw3m0FE*100
 replace  m_graw3m0FC= m_graw3m0FC*100
 replace  m_graw3m0F= m_graw3m0F*100
 
-* adjust values for acceptance probability (note, paper text incorrectly states pi=56% whereas it should be 55%)
+* adjust values for acceptance probability (note, there is a typo in the paper text and pi should be 0.55 instead)
 replace Af=Af/(1-0.55)
 replace AfE=AfE/(1-0.55)
 replace AfC=AfC/(1-0.55)

--- a/Code/PatentValueCites.do
+++ b/Code/PatentValueCites.do
@@ -88,6 +88,12 @@ replace  m_graw3m0FE= m_graw3m0FE*100
 replace  m_graw3m0FC= m_graw3m0FC*100
 replace  m_graw3m0F= m_graw3m0F*100
 
+* adjust values for acceptance probability (note, paper text incorrectly states pi=56% whereas it should be 55%)
+replace Af=Af/(1-0.55)
+replace AfE=AfE/(1-0.55)
+replace AfC=AfC/(1-0.55)
+
+
 * Descriptive statistics for the patent-level measure (Table 1 in the paper and A.6 in the Online Appendix)
 tabstat  ncites citeadj Ret m_graw3m0F Af m_graw3m0FE  AfE m_graw3m0FC AfC  , stat(mean sd p1 p5 p10 p25 p50 p75 p90 p95 p99)
 

--- a/Code/PatentValueScatterPlot.do
+++ b/Code/PatentValueScatterPlot.do
@@ -89,6 +89,11 @@ replace  m_graw3m0FE= m_graw3m0FE*100
 replace  m_graw3m0FC= m_graw3m0FC*100
 replace  m_graw3m0F= m_graw3m0F*100
 
+* adjust values for acceptance probability
+replace Af=Af/(1-0.55)
+replace AfE=AfE/(1-0.55)
+replace AfC=AfC/(1-0.55)
+
 * Descriptive statistics for the patent-level measure (Table 1 in the paper and A.6 in the Online Appendix)
 tabstat  ncites citeadj Ret m_graw3m0F Af m_graw3m0FE  AfE m_graw3m0FC AfC  , stat(mean sd p1 p5 p10 p25 p50 p75 p90 p95 p99)
 

--- a/Code/TimeSeriesPlots.do
+++ b/Code/TimeSeriesPlots.do
@@ -54,7 +54,7 @@ drop if _merge==2
 drop _merge
 
 
-gen ValuePerPatent=Af/AfNpats/cpi
+gen ValuePerPatent=Af/(1-0.55)/AfNpats/cpi
 
 gen logValuePerPatent=log(ValuePerPatent)
 

--- a/Data/cpi.dta
+++ b/Data/cpi.dta
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a066110fc6f84055cad6218e22672fa7476a623942c1d4f16c737ef97a0d7c79
-size 2778
+oid sha256:9cf155ff3f289e7cbf2cd0d1565b95f5005e095c78871dd85c74c5196e94c1a0
+size 4543

--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ In order for the code to run correctly, you need the following packages installe
 	
 - **AggregateOutput.do**: Runs the aggregate OLS regressions and VARs that relate our two innovation indices to output and TFP (The regression results for Figure 5  in the paper and Figure A.3 in the Online Appendix)
 
-#### Additional Notes:
-
-- Paper text incorrectly states the average acceptance rate pi to be 56% whereas it should be 55%.
 
 
 ### Code files using Matlab:
@@ -86,7 +83,9 @@ In order for the code to run correctly, you need to install the following progra
 - **jbfill.m**: Define the function called in plot_OLS_responses.m which helps plot the confidence intervals
 
 
-#### Additional Notes:
+## Additional Notes:
+
+- There is a minor discrepancy between the value of average acceptance probabilty used in the codes and reported on page 677 (published version of the paper). This minor difference is due to a typo in the published version.
 
 - There are some minor discrepancies between the output that the code generates and the results reported in Table 5 (published version of the paper). These minor differences are due to typos in the published version.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ In order for the code to run correctly, you need the following packages installe
 	
 - **AggregateOutput.do**: Runs the aggregate OLS regressions and VARs that relate our two innovation indices to output and TFP (The regression results for Figure 5  in the paper and Figure A.3 in the Online Appendix)
 
+#### Additional Notes:
+
+- Paper text incorrectly states the average acceptance rate pi to be 56% whereas it should be 55%.
+
 
 ### Code files using Matlab:
 


### PR DESCRIPTION
This pull request makes the following updates:

- Update `Code/cpi.dta` to make the benchmark year 1982 have the index of 100. Related code files have been updated accordingly, which are `Code/PatentValueCites.do`, `Code/PatentValueScatterPlot.do` and `Code/TimeSeriesPlots.do`.
- Update the value of average acceptance probability to 0.55 as the paper text incorrectly states it as 0.56. This change is noted in `README.md` and `Code/FirmSummaryStats.do`.  